### PR TITLE
Clean up details to filter and sort by default

### DIFF
--- a/src/components/OrganizationDetailsTable.tsx
+++ b/src/components/OrganizationDetailsTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import gql from "graphql-tag";
 import { Table } from "antd";
+import { SortOrder } from "antd/lib/table/interface"
 import { useQuery } from "react-apollo";
 import { FracToPercent } from "../utils/display_utils"
 
@@ -91,6 +92,9 @@ function CompareDateStrings(a: string, b: string): number {
   return Date.parse(a) - Date.parse(b)
 }
 
+let default_sort: SortOrder;
+default_sort = 'descend'
+
 const columns = [
   {
     title: "Study Title",
@@ -106,6 +110,7 @@ const columns = [
     render: (text: string, record: ITrial) => <a href={'https://clinicaltrials.gov/ct2/show/' + record.id}>{text}</a>,
     filters: [{text: 'Results Due', value: '1'}],
     onFilter: (value: string, record: ITrial) => record.shouldHaveResults,
+    filteredValue: ['1']
   },
   {
     title: "Start Date",
@@ -117,7 +122,8 @@ const columns = [
     title: "Completion Date",
     dataIndex: "primaryCompletionDate",
     key: "primaryCompletionDate",
-    sorter: (a: ITrial, b: ITrial) => NullStringSorterFunction(CompareDateStrings, false)(a.primaryCompletionDate, b.primaryCompletionDate)
+    sorter: (a: ITrial, b: ITrial) => NullStringSorterFunction(CompareDateStrings, false)(a.primaryCompletionDate, b.primaryCompletionDate),
+    defaultSortOrder: default_sort,
   },
   {
     title: "Results Submitted",
@@ -127,12 +133,6 @@ const columns = [
       a.resultsFirstSubmitDate,
       b.resultsFirstSubmitDate
     )
-  },
-  {
-    title: "Study Updated At",
-    dataIndex: "lastUpdateSubmitDate",
-    key: "lastUpdateSubmitDate",
-    sorter: (a: ITrial, b: ITrial) => NullStringSorterFunction(CompareDateStrings, false)(a.lastUpdateSubmitDate, b.lastUpdateSubmitDate)
   },
 ]
 

--- a/src/components/OrganizationsTable.tsx
+++ b/src/components/OrganizationsTable.tsx
@@ -24,6 +24,7 @@ const columns = [
     key: "shouldHaveResultsCount",
     filters: [{text: '>20', value: '20'}, {text: '>50', value: '50'}],
     onFilter: (value: number, record: IOrganization) => (record.shouldHaveResultsCount - value) > 0,
+    filteredValue: ['20'],
 // This inexplicably doesn't work!!!!
 //     onFilter: (value: number, record: IOrganization) => record.shouldHaveResultsCount > value,
     sorter: (a: IOrganization, b: IOrganization) => a.shouldHaveResultsCount - b.shouldHaveResultsCount,


### PR DESCRIPTION
Details page defaults to filter by results due (which I'd actually included as an option but didn't even remember myself that it was there...) and sort by completion date. Added in a default filter on the org table as well so you can immediately jump into sorting by unreported results to explore.

Only tricky thing was figuring out that you set a default filter by using `filteredValue` rather than `defaultFilteredValue` 🙃