### PR TITLE
Implement better percentage display with values and bars

### DIFF
--- a/src/components/OrganizationDetailsTable.tsx
+++ b/src/components/OrganizationDetailsTable.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { Table, Spin, Tag, Alert } from "antd";
 import { SortOrder } from "antd/lib/table/interface";
 import { useQuery } from "react-apollo";
-import { fracToPercent, formatDate } from "utils/displayUtils";
+import { BarType } from "./PercentBar";
+import { PercentageTableCell } from "./PercentageTableCell";
+import { formatDate } from "utils/displayUtils";
 import {
   nullStringSorterFunction,
   compareDateStrings,
@@ -69,6 +71,19 @@ const columns = [
   },
 ];
 
+const percentColumnRender = (barType: BarType) => {
+  return function (text: string, record: IOrganization) {
+    return (
+      <PercentageTableCell
+        type={ barType }
+        fraction={ text }
+        total={ record.shouldHaveResultsCount }
+        decimalPlaces={ 0 }
+      ></PercentageTableCell>
+    );
+  }
+}
+
 const summaryColumns = [
   {
     title: "Regulated Trials",
@@ -79,19 +94,19 @@ const summaryColumns = [
     title: "Results on time (%)",
     dataIndex: "onTimeFrac",
     key: "onTimeFrac",
-    render: (text: string, record: IOrganization) => fracToPercent(text),
+    render: percentColumnRender(BarType.Success),
   },
   {
     title: "Results late (%)",
     dataIndex: "lateFrac",
     key: "lateFrac",
-    render: (text: string, record: IOrganization) => fracToPercent(text),
+    render: percentColumnRender(BarType.Warning),
   },
   {
     title: "Results unreported (%)",
     dataIndex: "missingFrac",
     key: "missingFrac",
-    render: (text: string, record: IOrganization) => fracToPercent(text),
+    render: percentColumnRender(BarType.Danger),
   },
 ];
 

--- a/src/components/OrganizationDetailsTable.tsx
+++ b/src/components/OrganizationDetailsTable.tsx
@@ -3,7 +3,7 @@ import { Table, Spin, Tag, Alert } from "antd";
 import { SortOrder } from "antd/lib/table/interface";
 import { useQuery } from "react-apollo";
 import { BarType } from "components/PercentBar";
-import { PercentageTableCell } from "components/PercentageTableCell";
+import { percentColumnRender } from "components/PercentageTableCell";
 import { formatDate } from "utils/displayUtils";
 import {
   nullStringSorterFunction,
@@ -11,7 +11,6 @@ import {
   compareStrings,
 } from "utils/sort";
 import {
-  IOrganization,
   ITrial,
   ITrialsForOrgResponse,
   GET_TRIALS_FOR_ORGANIZATION,
@@ -70,19 +69,6 @@ const columns = [
       ),
   },
 ];
-
-const percentColumnRender = (barType: BarType) => {
-  return function (text: string, record: IOrganization) {
-    return (
-      <PercentageTableCell
-        type={barType}
-        fraction={text}
-        total={record.shouldHaveResultsCount}
-        decimalPlaces={0}
-      ></PercentageTableCell>
-    );
-  };
-};
 
 const summaryColumns = [
   {

--- a/src/components/OrganizationDetailsTable.tsx
+++ b/src/components/OrganizationDetailsTable.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Table, Spin, Tag, Alert } from "antd";
 import { SortOrder } from "antd/lib/table/interface";
 import { useQuery } from "react-apollo";
-import { BarType } from "./PercentBar";
-import { PercentageTableCell } from "./PercentageTableCell";
+import { BarType } from "components/PercentBar";
+import { PercentageTableCell } from "components/PercentageTableCell";
 import { formatDate } from "utils/displayUtils";
 import {
   nullStringSorterFunction,
@@ -75,14 +75,14 @@ const percentColumnRender = (barType: BarType) => {
   return function (text: string, record: IOrganization) {
     return (
       <PercentageTableCell
-        type={ barType }
-        fraction={ text }
-        total={ record.shouldHaveResultsCount }
-        decimalPlaces={ 0 }
+        type={barType}
+        fraction={text}
+        total={record.shouldHaveResultsCount}
+        decimalPlaces={0}
       ></PercentageTableCell>
     );
-  }
-}
+  };
+};
 
 const summaryColumns = [
   {

--- a/src/components/OrganizationsTable.tsx
+++ b/src/components/OrganizationsTable.tsx
@@ -9,23 +9,10 @@ import {
   GET_ORGANIZATIONS,
 } from "graphql/queries";
 import { BarType } from "components/PercentBar";
-import { PercentageTableCell } from "components/PercentageTableCell";
+import { percentColumnRender } from "components/PercentageTableCell";
 
 let defaultSort: SortOrder;
 defaultSort = "descend";
-
-const percentColumnRender = (barType: BarType) => {
-  return function (text: string, record: IOrganization) {
-    return (
-      <PercentageTableCell
-        type={barType}
-        fraction={text}
-        total={record.shouldHaveResultsCount}
-        decimalPlaces={0}
-      ></PercentageTableCell>
-    );
-  };
-};
 
 const columns = [
   {

--- a/src/components/OrganizationsTable.tsx
+++ b/src/components/OrganizationsTable.tsx
@@ -3,15 +3,29 @@ import { Table, Spin, Alert } from "antd";
 import { SortOrder } from "antd/lib/table/interface";
 import { Link } from "react-router-dom";
 import { useQuery } from "react-apollo";
-import { fracToPercent } from "utils/displayUtils";
 import {
   IOrganization,
   IAllOrganizations,
   GET_ORGANIZATIONS,
 } from "graphql/queries";
+import { BarType } from "./PercentBar";
+import { PercentageTableCell } from "./PercentageTableCell";
 
 let defaultSort: SortOrder;
 defaultSort = "descend";
+
+const percentColumnRender = (barType: BarType) => {
+  return function (text: string, record: IOrganization) {
+    return (
+      <PercentageTableCell
+        type={ barType }
+        fraction={ text }
+        total={ record.shouldHaveResultsCount }
+        decimalPlaces={ 0 }
+      ></PercentageTableCell>
+    );
+  }
+}
 
 const columns = [
   {
@@ -55,21 +69,21 @@ const columns = [
     title: "Results on time (%)",
     dataIndex: "onTimeFrac",
     key: "onTimeFrac",
-    render: (text: string, record: IOrganization) => fracToPercent(text),
+    render: percentColumnRender(BarType.Success),
     sorter: (a: IOrganization, b: IOrganization) => a.onTimeFrac - b.onTimeFrac,
   },
   {
     title: "Results late (%)",
     dataIndex: "lateFrac",
     key: "lateFrac",
-    render: (text: string, record: IOrganization) => fracToPercent(text),
+    render: percentColumnRender(BarType.Warning),
     sorter: (a: IOrganization, b: IOrganization) => a.lateFrac - b.lateFrac,
   },
   {
     title: "Results unreported (%)",
     dataIndex: "missingFrac",
     key: "missingFrac",
-    render: (text: string, record: IOrganization) => fracToPercent(text),
+    render: percentColumnRender(BarType.Danger),
     sorter: (a: IOrganization, b: IOrganization) =>
       a.missingFrac - b.missingFrac,
   },

--- a/src/components/OrganizationsTable.tsx
+++ b/src/components/OrganizationsTable.tsx
@@ -8,8 +8,8 @@ import {
   IAllOrganizations,
   GET_ORGANIZATIONS,
 } from "graphql/queries";
-import { BarType } from "./PercentBar";
-import { PercentageTableCell } from "./PercentageTableCell";
+import { BarType } from "components/PercentBar";
+import { PercentageTableCell } from "components/PercentageTableCell";
 
 let defaultSort: SortOrder;
 defaultSort = "descend";
@@ -18,14 +18,14 @@ const percentColumnRender = (barType: BarType) => {
   return function (text: string, record: IOrganization) {
     return (
       <PercentageTableCell
-        type={ barType }
-        fraction={ text }
-        total={ record.shouldHaveResultsCount }
-        decimalPlaces={ 0 }
+        type={barType}
+        fraction={text}
+        total={record.shouldHaveResultsCount}
+        decimalPlaces={0}
       ></PercentageTableCell>
     );
-  }
-}
+  };
+};
 
 const columns = [
   {

--- a/src/components/PercentBar.tsx
+++ b/src/components/PercentBar.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { numericValue } from '../utils/displayUtils';
+
+export enum BarType {
+  Success = '#027d11',
+  Warning = '#c9bc2a',
+  Danger = '#8a0b0b',
+  Neutral = '#e8e4d8',
+  LightGray = '#e3e3e3',
+  Grey = '#9c9c9c',
+  Black = '#000000'
+}
+
+export function PercentBar({ type, fraction }: {
+  type: BarType,
+  fraction: number
+}) {
+  const backStyles = {
+    backgroundColor: `${BarType.Neutral}`,
+    width: '100%',
+    height: '6px'
+  };
+  const foreStyles = {
+    backgroundColor: `${ type }`,
+    width: `${(numericValue(fraction) * 100).toFixed(0)}%`,
+    height: '100%',
+    padding: 0,
+    margin: 0,
+    left: 0
+  };
+  return (
+    <>
+      <div
+        className="percent-bar"
+        style={backStyles}
+      >
+        <div style={foreStyles}></div>
+      </div>
+    </>
+  )
+}

--- a/src/components/PercentBar.tsx
+++ b/src/components/PercentBar.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { numericValue } from "utils/displayUtils";
 
 export enum BarType {
-  Success = "#027d11",
-  Warning = "#c9bc2a",
-  Danger = "#8a0b0b",
-  Neutral = "#e8e4d8",
-  LightGray = "#e3e3e3",
-  Grey = "#9c9c9c",
-  Black = "#000000",
+  Success = "#237804",   // antd @green-8
+  Warning = "#d4b106",   // antd @yellow-7
+  Danger = "#820014",    // antd @red-9
+  Neutral = "#fffbe6",   // antd @gold-1
+  LightGray = "#f0f0f0", // antd @gray-4
+  Grey = "#8c8c8c",      // antd @gray-7
+  Black = "#000000",     // antd @gray-13
 }
 
 export function PercentBar({

--- a/src/components/PercentBar.tsx
+++ b/src/components/PercentBar.tsx
@@ -1,41 +1,41 @@
-import React from 'react';
-import { numericValue } from '../utils/displayUtils';
+import React from "react";
+import { numericValue } from "utils/displayUtils";
 
 export enum BarType {
-  Success = '#027d11',
-  Warning = '#c9bc2a',
-  Danger = '#8a0b0b',
-  Neutral = '#e8e4d8',
-  LightGray = '#e3e3e3',
-  Grey = '#9c9c9c',
-  Black = '#000000'
+  Success = "#027d11",
+  Warning = "#c9bc2a",
+  Danger = "#8a0b0b",
+  Neutral = "#e8e4d8",
+  LightGray = "#e3e3e3",
+  Grey = "#9c9c9c",
+  Black = "#000000",
 }
 
-export function PercentBar({ type, fraction }: {
-  type: BarType,
-  fraction: number
+export function PercentBar({
+  type,
+  fraction,
+}: {
+  type: BarType;
+  fraction: number;
 }) {
   const backStyles = {
     backgroundColor: `${BarType.Neutral}`,
-    width: '100%',
-    height: '6px'
+    width: "100%",
+    height: "6px",
   };
   const foreStyles = {
-    backgroundColor: `${ type }`,
+    backgroundColor: `${type}`,
     width: `${(numericValue(fraction) * 100).toFixed(0)}%`,
-    height: '100%',
+    height: "100%",
     padding: 0,
     margin: 0,
-    left: 0
+    left: 0,
   };
   return (
     <>
-      <div
-        className="percent-bar"
-        style={backStyles}
-      >
+      <div className="percent-bar" style={backStyles}>
         <div style={foreStyles}></div>
       </div>
     </>
-  )
+  );
 }

--- a/src/components/PercentWithValue.tsx
+++ b/src/components/PercentWithValue.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { numericValue, fracToPercent } from '../utils/displayUtils';
+
+export function PercentWithValue({ rawTotal, fraction, decimalPlaces }: {
+  rawTotal: number | undefined
+  fraction: string | number,
+  decimalPlaces: number,
+}) {
+  const percentage = fracToPercent(fraction, decimalPlaces);
+  const raw = rawTotal ?
+    (numericValue(fraction) * rawTotal).toFixed(0) :
+    undefined;
+  const textDisplay =  raw ?
+    <span><strong>{ percentage } %</strong> ( { raw } )</span> :
+    <span><strong>{ percentage } %</strong></span>;
+  return textDisplay;
+}

--- a/src/components/PercentWithValue.tsx
+++ b/src/components/PercentWithValue.tsx
@@ -1,17 +1,27 @@
-import React from 'react';
-import { numericValue, fracToPercent } from '../utils/displayUtils';
+import React from "react";
+import { numericValue, fracToPercent } from "utils/displayUtils";
 
-export function PercentWithValue({ rawTotal, fraction, decimalPlaces }: {
-  rawTotal: number | undefined
-  fraction: string | number,
-  decimalPlaces: number,
+export function PercentWithValue({
+  rawTotal,
+  fraction,
+  decimalPlaces,
+}: {
+  rawTotal: number | undefined;
+  fraction: string | number;
+  decimalPlaces: number;
 }) {
   const percentage = fracToPercent(fraction, decimalPlaces);
-  const raw = rawTotal ?
-    (numericValue(fraction) * rawTotal).toFixed(0) :
-    undefined;
-  const textDisplay =  raw ?
-    <span><strong>{ percentage } %</strong> ( { raw } )</span> :
-    <span><strong>{ percentage } %</strong></span>;
+  const raw = rawTotal
+    ? (numericValue(fraction) * rawTotal).toFixed(0)
+    : undefined;
+  const textDisplay = raw ? (
+    <span>
+      <strong>{percentage} %</strong> ( {raw} )
+    </span>
+  ) : (
+    <span>
+      <strong>{percentage} %</strong>
+    </span>
+  );
   return textDisplay;
 }

--- a/src/components/PercentageTableCell.tsx
+++ b/src/components/PercentageTableCell.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { PercentWithValue } from './PercentWithValue';
+import { PercentBar, BarType } from './PercentBar';
+import { numericValue } from 'utils/displayUtils';
+
+export function PercentageTableCell({ type, fraction, total, decimalPlaces }: {
+  type: BarType,
+  fraction: string | number,
+  total: number,
+  decimalPlaces: number
+}) {
+  const val = numericValue(fraction);
+  return (
+    <>
+      <PercentWithValue
+        rawTotal={total}
+        fraction={val}
+        decimalPlaces={decimalPlaces}
+      ></PercentWithValue>
+      <PercentBar
+        type={type}
+        fraction={val}
+      ></PercentBar>
+    </>
+  )  
+}

--- a/src/components/PercentageTableCell.tsx
+++ b/src/components/PercentageTableCell.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { PercentWithValue } from "components/PercentWithValue";
 import { PercentBar, BarType } from "components/PercentBar";
 import { numericValue } from "utils/displayUtils";
+import { IOrganization } from "graphql/queries";
 
 export function PercentageTableCell({
   type,
@@ -26,3 +27,18 @@ export function PercentageTableCell({
     </>
   );
 }
+
+type PercentColumnRenderer = (text: string, record: IOrganization) => React.ReactElement;
+
+export function percentColumnRender (barType: BarType): PercentColumnRenderer {
+  return function (text: string, record: IOrganization) {
+    return (
+      <PercentageTableCell
+        type={barType}
+        fraction={text}
+        total={record.shouldHaveResultsCount}
+        decimalPlaces={0}
+      ></PercentageTableCell>
+    );
+  };
+};

--- a/src/components/PercentageTableCell.tsx
+++ b/src/components/PercentageTableCell.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
-import { PercentWithValue } from './PercentWithValue';
-import { PercentBar, BarType } from './PercentBar';
-import { numericValue } from 'utils/displayUtils';
+import React from "react";
+import { PercentWithValue } from "components/PercentWithValue";
+import { PercentBar, BarType } from "components/PercentBar";
+import { numericValue } from "utils/displayUtils";
 
-export function PercentageTableCell({ type, fraction, total, decimalPlaces }: {
-  type: BarType,
-  fraction: string | number,
-  total: number,
-  decimalPlaces: number
+export function PercentageTableCell({
+  type,
+  fraction,
+  total,
+  decimalPlaces,
+}: {
+  type: BarType;
+  fraction: string | number;
+  total: number;
+  decimalPlaces: number;
 }) {
   const val = numericValue(fraction);
   return (
@@ -17,10 +22,7 @@ export function PercentageTableCell({ type, fraction, total, decimalPlaces }: {
         fraction={val}
         decimalPlaces={decimalPlaces}
       ></PercentWithValue>
-      <PercentBar
-        type={type}
-        fraction={val}
-      ></PercentBar>
+      <PercentBar type={type} fraction={val}></PercentBar>
     </>
-  )  
+  );
 }

--- a/src/utils/displayUtils.test.ts
+++ b/src/utils/displayUtils.test.ts
@@ -1,0 +1,40 @@
+import {
+  fracToPercent,
+  formatDate,
+  numericValue
+} from './displayUtils';
+
+describe('displayUtils', () => {
+  describe('numericValue', () => {
+    it('converts a string to a numeric value', () => {
+      expect(numericValue('4.3563')).toEqual(4.3563);
+    });
+    it('returns a numeric value unchanged', () => {
+      expect(numericValue(4.3563)).toEqual(4.3563);
+    });
+  });
+  describe('fracToPercent', () => {
+    it('converts a floating point string value to a percentage', () => {
+      expect(fracToPercent('0.356352')).toEqual('36');
+      expect(fracToPercent('0.356352', 0)).toEqual('36');
+      expect(fracToPercent('0.356352', 1)).toEqual('35.6')
+      expect(fracToPercent('0.356352', 2)).toEqual('35.64')
+      expect(fracToPercent('0.356352', 3)).toEqual('35.635')
+      expect(fracToPercent('0.356352', 4)).toEqual('35.6352')
+      expect(fracToPercent('0.356352', 5)).toEqual('35.63520')
+      expect(fracToPercent('4.356352')).toEqual('436');
+      expect(fracToPercent('4.356352', 0)).toEqual('436');
+      expect(fracToPercent('4.356352', 1)).toEqual('435.6')
+      expect(fracToPercent('4.356352', 2)).toEqual('435.64')
+      expect(fracToPercent('4.356352', 3)).toEqual('435.635')
+      expect(fracToPercent('4.356352', 4)).toEqual('435.6352')
+      expect(fracToPercent('4.356352', 5)).toEqual('435.63520')
+    });
+  });
+  describe('formatDate', () => {
+    it('formats dates in year-month-date format', () => {
+      const d = new Date(1982, 3, 7);
+      expect(formatDate(d)).toEqual('1982-04-07');
+    });
+  });
+});

--- a/src/utils/displayUtils.test.ts
+++ b/src/utils/displayUtils.test.ts
@@ -1,40 +1,36 @@
-import {
-  fracToPercent,
-  formatDate,
-  numericValue
-} from './displayUtils';
+import { fracToPercent, formatDate, numericValue } from "utils/displayUtils";
 
-describe('displayUtils', () => {
-  describe('numericValue', () => {
-    it('converts a string to a numeric value', () => {
-      expect(numericValue('4.3563')).toEqual(4.3563);
+describe("displayUtils", () => {
+  describe("numericValue", () => {
+    it("converts a string to a numeric value", () => {
+      expect(numericValue("4.3563")).toEqual(4.3563);
     });
-    it('returns a numeric value unchanged', () => {
+    it("returns a numeric value unchanged", () => {
       expect(numericValue(4.3563)).toEqual(4.3563);
     });
   });
-  describe('fracToPercent', () => {
-    it('converts a floating point string value to a percentage', () => {
-      expect(fracToPercent('0.356352')).toEqual('36');
-      expect(fracToPercent('0.356352', 0)).toEqual('36');
-      expect(fracToPercent('0.356352', 1)).toEqual('35.6')
-      expect(fracToPercent('0.356352', 2)).toEqual('35.64')
-      expect(fracToPercent('0.356352', 3)).toEqual('35.635')
-      expect(fracToPercent('0.356352', 4)).toEqual('35.6352')
-      expect(fracToPercent('0.356352', 5)).toEqual('35.63520')
-      expect(fracToPercent('4.356352')).toEqual('436');
-      expect(fracToPercent('4.356352', 0)).toEqual('436');
-      expect(fracToPercent('4.356352', 1)).toEqual('435.6')
-      expect(fracToPercent('4.356352', 2)).toEqual('435.64')
-      expect(fracToPercent('4.356352', 3)).toEqual('435.635')
-      expect(fracToPercent('4.356352', 4)).toEqual('435.6352')
-      expect(fracToPercent('4.356352', 5)).toEqual('435.63520')
+  describe("fracToPercent", () => {
+    it("converts a floating point string value to a percentage", () => {
+      expect(fracToPercent("0.356352")).toEqual("36");
+      expect(fracToPercent("0.356352", 0)).toEqual("36");
+      expect(fracToPercent("0.356352", 1)).toEqual("35.6");
+      expect(fracToPercent("0.356352", 2)).toEqual("35.64");
+      expect(fracToPercent("0.356352", 3)).toEqual("35.635");
+      expect(fracToPercent("0.356352", 4)).toEqual("35.6352");
+      expect(fracToPercent("0.356352", 5)).toEqual("35.63520");
+      expect(fracToPercent("4.356352")).toEqual("436");
+      expect(fracToPercent("4.356352", 0)).toEqual("436");
+      expect(fracToPercent("4.356352", 1)).toEqual("435.6");
+      expect(fracToPercent("4.356352", 2)).toEqual("435.64");
+      expect(fracToPercent("4.356352", 3)).toEqual("435.635");
+      expect(fracToPercent("4.356352", 4)).toEqual("435.6352");
+      expect(fracToPercent("4.356352", 5)).toEqual("435.63520");
     });
   });
-  describe('formatDate', () => {
-    it('formats dates in year-month-date format', () => {
+  describe("formatDate", () => {
+    it("formats dates in year-month-date format", () => {
       const d = new Date(1982, 3, 7);
-      expect(formatDate(d)).toEqual('1982-04-07');
+      expect(formatDate(d)).toEqual("1982-04-07");
     });
   });
 });

--- a/src/utils/displayUtils.ts
+++ b/src/utils/displayUtils.ts
@@ -1,11 +1,16 @@
 import moment from "moment";
 
+export function numericValue(
+  fraction: string | number
+) {
+  return typeof fraction === "string" ? parseFloat(fraction) : fraction;
+}
+
 export function fracToPercent(
   fraction: string | number,
   decimalPlaces = 0,
 ): string {
-  const value = typeof fraction === "string" ? parseFloat(fraction) : fraction;
-  return (value * 100).toFixed(decimalPlaces);
+  return (numericValue(fraction) * 100).toFixed(decimalPlaces);
 }
 
 export function formatDate(d: Date): string {

--- a/src/utils/displayUtils.ts
+++ b/src/utils/displayUtils.ts
@@ -1,8 +1,6 @@
 import moment from "moment";
 
-export function numericValue(
-  fraction: string | number
-) {
+export function numericValue(fraction: string | number) {
   return typeof fraction === "string" ? parseFloat(fraction) : fraction;
 }
 


### PR DESCRIPTION
@dstuck shared this with me. The percentages were difficult to digest on my first look at this, and I thought it would be good to modify the display so that the meaning jumps out at you when you first look at it.

I implemented that by bolding the percentages (with the "%" sign behind them), adding the raw values they represent, and adding a minimal bar graph display beneath each to show what that means in context. The bar graphs also use color to show the meaning of the column as well.

![ui-updates](https://user-images.githubusercontent.com/479496/82027037-43aeb400-9659-11ea-96a7-ca7206f4c3e9.png)

In the course of doing that, I also added a few tests for the display utils stuff. I didn't take the time to add tests for all the new components here, but I could do that if needed -- I just won't likely have time until the weekend at the earliest.

Happy to discuss or update as needed.